### PR TITLE
preserve table state when switching tabs

### DIFF
--- a/src/components/DemandTable.vue
+++ b/src/components/DemandTable.vue
@@ -5,6 +5,8 @@
     show-select
     item-key="id"
     class="elevation-1"
+    :options="preferences"
+    @update:options="(e) => handleSortBy('demand', e)"
   >
     <template v-slot:top>
       <v-toolbar
@@ -31,6 +33,7 @@ export default {
       demandData,
     };
   },
+  props: ['preferences', 'handleSortBy'],
 };
 </script>
 

--- a/src/components/SupplyTable.vue
+++ b/src/components/SupplyTable.vue
@@ -5,6 +5,8 @@
     show-select
     item-key="id"
     class="elevation-1"
+    :options="preferences"
+    @update:options="(e) => handleSortBy('supply', e)"
   >
     <template v-slot:top>
       <v-toolbar
@@ -31,6 +33,7 @@ export default {
       supplyData,
     };
   },
+  props: ['preferences', 'handleSortBy'],
 };
 </script>
 

--- a/src/views/dashboard/Dashboard.vue
+++ b/src/views/dashboard/Dashboard.vue
@@ -27,7 +27,11 @@
         </v-tabs>
 
         <v-slide-x-transition mode="out-in">
-          <router-view></router-view>
+          <router-view
+            :demandTablePrefs="demandTablePrefs"
+            :supplyTablePrefs="supplyTablePrefs"
+            :handleSortBy="handleSortBy"
+          />
         </v-slide-x-transition>
       </v-col>
     </v-row>
@@ -35,10 +39,65 @@
 </template>
 
 <script>
+import supplyData from '../../../mocks/raw/supply';
+import demandData from '../../../mocks/raw/demand';
+
 export default {
   name: 'Dashboard',
+  methods: {
+    handleSortBy(table, prefs) {
+      console.log(table, prefs);
+      switch (table) {
+        case 'supply': {
+          this.supplyTablePrefs = prefs;
+          break;
+        }
+        case 'demand': {
+          this.demandTablePrefs = prefs;
+          break;
+        }
+        default: {
+          console.warn('error');
+        }
+      }
+    },
+  },
   created() {
-    if (this.$route.name === 'dashboard') this.$router.replace({ name: 'supply' });
+    if (this.$route.name === 'dashboard') { this.$router.replace({ name: 'supply' }); }
+
+    /*
+    // TODO extract this function but not sure how to do so the vue way
+    // do we support geolocation
+    if (!('geolocation' in navigator)) {
+      this.errorStr = 'Geolocation is not available.';
+      return;
+    }
+
+    this.gettingLocation = true;
+    // get position
+    navigator.geolocation.getCurrentPosition((pos) => {
+      // this.gettingLocation = false;
+      this.state.currentLocation = pos;
+    }, (err) => {
+      // this.gettingLocation = false;
+      // this.errorStr = err.message;
+      console.log(err);
+    }); */
+  },
+  data() {
+    return {
+      currentLocation: {},
+      supplyQuery: {},
+      supplyResults: supplyData,
+      supplyTablePrefs: {
+        sortBy: ['distanceKm'],
+      },
+      demandQuery: {},
+      demandResults: demandData,
+      demandTablePrefs: {
+        sortBy: ['distanceKm'],
+      },
+    };
   },
 };
 </script>

--- a/src/views/dashboard/Demand.vue
+++ b/src/views/dashboard/Demand.vue
@@ -1,6 +1,6 @@
 <template>
   <v-col>
-    <DemandTable view="demand" />
+    <DemandTable :preferences="demandTablePrefs" :handleSortBy="handleSortBy" />
   </v-col>
 </template>
 
@@ -12,6 +12,7 @@ export default {
   components: {
     DemandTable,
   },
+  props: ['demandTablePrefs', 'handleSortBy'],
 };
 </script>
 

--- a/src/views/dashboard/Distribute.vue
+++ b/src/views/dashboard/Distribute.vue
@@ -7,10 +7,10 @@
     </v-card>
     <v-row>
       <v-col>
-        <SupplyTable />
+        <SupplyTable :preferences="supplyTablePrefs" :handleSortBy="handleSortBy"  />
       </v-col>
       <v-col>
-        <DemandTable />
+        <DemandTable :preferences="demandTablePrefs" :handleSortBy="handleSortBy" />
       </v-col>
     </v-row>
   </v-col>
@@ -25,6 +25,11 @@ export default {
   components: {
     SupplyTable,
     DemandTable,
+  },
+  props: {
+    demandTablePrefs: { type: Object },
+    supplyTablePrefs: { type: Object },
+    handleSortBy: { type: Function },
   },
 };
 </script>

--- a/src/views/dashboard/Supply.vue
+++ b/src/views/dashboard/Supply.vue
@@ -1,6 +1,6 @@
 <template>
   <v-col>
-    <SupplyTable view="supply" />
+    <SupplyTable :preferences="supplyTablePrefs" :handleSortBy="handleSortBy" />
   </v-col>
 </template>
 
@@ -12,6 +12,7 @@ export default {
   components: {
     SupplyTable,
   },
+  props: ['supplyTablePrefs', 'handleSortBy'],
 };
 </script>
 


### PR DESCRIPTION
I noticed that when switching tabs, the tables lose their state (sort order etc) so I solved it while as an exercise in understanding basic Vue prop/state management.